### PR TITLE
Display dragable axes 

### DIFF
--- a/static/app/scripts/controllers/plotCtrl.js
+++ b/static/app/scripts/controllers/plotCtrl.js
@@ -257,11 +257,6 @@ app.controller('plotController', function ($scope, ocpuService) {
           .datum(tests)
           .attr('d', lowerMarginArea);
 
-    // add mean line
-    linesGraph.append('path')
-        .attr('class', 'mean-line')
-        .attr('d', pathMean);
-
     // add grey lines for context
     backgroundLines = linesGraph.append('g')
         .attr('class', 'background-lines')
@@ -405,6 +400,11 @@ app.controller('plotController', function ($scope, ocpuService) {
           .transition()
             .style('font-size', 11);
         });
+
+    // add mean line
+    linesGraph.append('path')
+        .attr('class', 'mean-line')
+        .attr('d', pathMean);
 
     // add visible, undragable y axis
     // This axis only has integers as labels, because otherwise the y axis label

--- a/static/app/scripts/controllers/plotCtrl.js
+++ b/static/app/scripts/controllers/plotCtrl.js
@@ -202,6 +202,11 @@ app.controller('plotController', function ($scope, ocpuService) {
 
     var yAxis = d3.svg.axis()
       .scale(yScale)
+      .tickFormat(function (d) { return ''; })
+      .orient('left');
+
+    var yAxisFixed = d3.svg.axis()
+      .scale(yScale)
       .orient('left');
 
     xAxis.domain(tests);
@@ -381,9 +386,9 @@ app.controller('plotController', function ($scope, ocpuService) {
                 .attr("visibility", null);
           }));
 
-    // add invisible, dragable y axis for each test
+    // add dragable y axis for each test
     g.append('g')
-        .attr('class', 'axis hide-axis')
+        .attr('class', 'axis')
         .each(function(d) { d3.select(this).call(yAxis.scale(y[d])); })
       .append('text')
         .style("text-anchor", "middle")
@@ -404,10 +409,10 @@ app.controller('plotController', function ($scope, ocpuService) {
     // add visible, undragable y axis
     // This axis only has integers as labels, because otherwise the y axis label
     // placement is suboptimal.
-    yAxis.tickFormat(d3.format('d'));
+    yAxisFixed.tickFormat(d3.format('d'));
     var yaxis = linesGraph.append('g')
       .attr('class', 'axis')
-      .call(yAxis);
+      .call(yAxisFixed);
 
     // mean/normal labels on y axis
     var axisPadding = 5;


### PR DESCRIPTION
With tick marks, but without tick mark text, to make it more visible what test variables the points correspond to.
