### PR TITLE
Update to node v6.7.0 and use eslint in dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.5-onbuild
 
 # install nodejs
-ENV NODE_VERSION="v6.3.1"
+ENV NODE_VERSION="v6.7.0"
 RUN curl -LO http://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz
 RUN tar xzf node-$NODE_VERSION-linux-x64.tar.gz
 RUN cp -rp node-$NODE_VERSION-linux-x64 /usr/local/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "connect": "^3.4.1",
     "eslint": "^2.13.1",
+    "eslint-plugin-standard": "^1.3.2",
     "grunt": "^1.0.1",
     "grunt-angular-templates": "^1.0.3",
     "grunt-autoprefixer": "^3.0.4",
@@ -44,7 +45,6 @@
   },
   "dependencies": {
     "babyparse": "^0.4.6",
-    "eslint-plugin-standard": "^1.3.2",
     "lodash": "^4.13.1"
   }
 }


### PR DESCRIPTION
Somehow bumping the version of nodejs solves the issue.
Additionaly eslit related plugins should not be installed
in production

Fixes issue #150
