### PR TITLE
Pin python package versions to minor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Django==1.9.7
-django-angular==0.8.2
+Django==1.9.*
+django-angular==0.8.*
 -e git+https://github.com/kristjanr/django-csvimport.git@af1700ca650ec26763fa78bd44810c98e01866df#egg=django-csvimport
-django-userena==2.0.1
-requests==2.10.0
-gunicorn
-lxml==3.6.4
-cssselect==0.9.2
-tinycss==0.4
-CairoSVG==1.0.22
+django-userena==2.0.*
+requests==2.10.*
+gunicorn==19.6.*
+lxml==3.6.*
+cssselect==0.9.*
+tinycss==0.4.*
+CairoSVG==1.0.*


### PR DESCRIPTION
Patches will be installed but the version will be
kept to first two digits.